### PR TITLE
Add default value of 'False' to flag

### DIFF
--- a/utf8-string.cabal
+++ b/utf8-string.cabal
@@ -15,6 +15,7 @@ Build-type:         Simple
 cabal-version:      >= 1.2
 
 flag bytestring-in-base
+  default: False
 
 library
   Ghc-options:        -W -O2


### PR DESCRIPTION
Hi,

Doing a straight 'cabal install' on a clean unpack or clone does not work because it sets the bytestring-in-base flag, causing bytestring not to be listed as a separate dependency. Indeed, running 'cabal install utf8-string' from a clean directory also fails for the same reason.

Running 'cabal configure' followed by 'cabal install' works just fine.

This patch sets the default value of this flag to 'false' which fixes my problem.

I'm using Cabal 1.20.0.0 if that makes any difference.

Cheers,

David
