### PR TITLE
Allow building with GHC 8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
       compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.2
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,15 @@ matrix:
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.2
-      compiler: ": #GHC 7.10.2"
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.2
+      compiler: ": #GHC 8.0.2"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.2.1
+      compiler: ": #GHC 8.2.1"
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.1], sources: [hvr-ghc]}}
 
 before_install:
  - unset CC
@@ -59,7 +65,7 @@ install:
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
      cabal install --only-dependencies --enable-tests --enable-benchmarks;
    fi
- 
+
 # snapshot package-db on cache miss
  - if [ ! -d $HOME/.cabsnap ];
    then

--- a/utf8-string.cabal
+++ b/utf8-string.cabal
@@ -24,7 +24,7 @@ source-repository head
 library
   Ghc-options:        -W -O2
 
-  build-depends:      base >= 4.3 && < 4.10, bytestring >= 0.9
+  build-depends:      base >= 4.3 && < 4.11, bytestring >= 0.9
 
   Exposed-modules:    Codec.Binary.UTF8.String
                       Codec.Binary.UTF8.Generic
@@ -37,5 +37,5 @@ library
 test-suite unit-tests
   type:               exitcode-stdio-1.0
   main-is:            tests/Tests.hs
-  build-depends:      base, HUnit >= 1.3 && < 1.4
+  build-depends:      base, HUnit >= 1.3 && < 1.7
   default-language:   Haskell2010

--- a/utf8-string.cabal
+++ b/utf8-string.cabal
@@ -15,7 +15,7 @@ Category:           Codec
 Build-type:         Simple
 cabal-version:      >= 1.10
 Extra-Source-Files: CHANGELOG.markdown
-Tested-With:        GHC==7.0.4, GHC==7.4.2, GHC==7.6.3, GHC==7.8.4, GHC==7.10.2
+Tested-With:        GHC==7.0.4, GHC==7.4.2, GHC==7.6.3, GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.1
 
 source-repository head
   type:               git


### PR DESCRIPTION
This accomplishes the following:

* Bumps the upper version bounds on `base` (and `HUnit`, since it's also outdated)
* Updates `.travis.yml` accordingly so that GHC 8.2 (and 8.0, since it was missing) is tested